### PR TITLE
shard registration speed & stdout/stderr hotfix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "discord-compiler-bot"
 description = "Discord bot to compile your spaghetti code."
-version = "0.1.1"
+version = "0.1.2"
 authors = ["ThomasByr"]
 edition = "2021"
 build = "src/build.rs"
@@ -34,10 +34,8 @@ chrono = "0.4.19"
 
 [dependencies.serenity]
 version = "0.11"
-#git = "https://github.com/serenity-rs/serenity"
-#branch = "current"
 default-features = false
-features = ["collector", "gateway", "builder", "standard_framework", "http", "model", "client", "framework", "utils", "rustls_backend", "unstable_discord_api"]
+features = ["collector", "gateway", "builder", "standard_framework", "http", "model", "client", "framework", "utils", "rustls_backend"]
 
 [dependencies.wandbox]
 path = "wandbox"

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 - cargo clippy to help keep the code cleaner
 - deactivated local execution for some guilds
 - `;block` and `;unblock` commands working (blacklist)
+- added boilerplate code for some languages
 
 </details>
 

--- a/changelog.md
+++ b/changelog.md
@@ -25,3 +25,4 @@
 - cargo clippy to help keep the code cleaner
 - deactivated local execution for some guilds
 - `;block` and `;unblock` commands working (blacklist)
+- added boilerplate code for some languages

--- a/src/boilerplate/cpp.rs
+++ b/src/boilerplate/cpp.rs
@@ -1,0 +1,46 @@
+use crate::boilerplate::generator::BoilerPlateGenerator;
+use regex::Regex;
+
+pub struct CppGenerator {
+    input: String,
+}
+
+impl BoilerPlateGenerator for CppGenerator {
+    fn new(input: &str) -> Self {
+        let mut formated = input.to_string();
+        formated = formated.replace(';', ";\n"); // separate lines by ;
+
+        Self { input: formated }
+    }
+
+    fn generate(&self) -> String {
+        let mut main_body = String::default();
+        let mut header = String::default();
+
+        let lines = self.input.split('\n');
+        for line in lines {
+            let trimmed = line.trim();
+            if trimmed.starts_with("using") || trimmed.starts_with("#i") {
+                header.push_str(&format!("{}\n", trimmed));
+            } else {
+                main_body.push_str(&format!("{}\n", trimmed))
+            }
+        }
+
+        // if they included nothing, we can just manually include everything
+        if !header.contains("#include") {
+            header.push_str("#include <bits/stdc++.h>");
+        }
+        format!("{}\nint main(void) {{\n{}return 0;\n}}", header, main_body)
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        let cpp_main_regex: Regex = Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
+        for m in cpp_main_regex.captures_iter(&self.input) {
+            if m.name("main").is_some() {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/src/boilerplate/csharp.rs
+++ b/src/boilerplate/csharp.rs
@@ -1,0 +1,50 @@
+use crate::boilerplate::generator::BoilerPlateGenerator;
+use regex::Regex;
+
+pub struct CSharpGenerator {
+    input: String,
+}
+
+impl BoilerPlateGenerator for CSharpGenerator {
+    fn new(input: &str) -> Self {
+        let mut formated = input.to_string();
+        formated = formated.replace(';', ";\n"); // separate lines by ;
+
+        Self { input: formated }
+    }
+
+    fn generate(&self) -> String {
+        let mut main_body = String::default();
+        let mut header = String::default();
+
+        let lines = self.input.split('\n');
+        for line in lines {
+            let trimmed = line.trim();
+            if trimmed.starts_with("using") {
+                header.push_str(&format!("{}\n", trimmed));
+            } else {
+                main_body.push_str(&format!("{}\n", trimmed))
+            }
+        }
+
+        // if they included nothing, we can just manually include System since they probably want it
+        if header.is_empty() {
+            header.push_str("using System;");
+        }
+        format!(
+            "{}\nnamespace Main{{\nclass Program {{\n static void Main(string[] args) {{\n{}}}}}}}",
+            header, main_body
+        )
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        let cpp_main_regex: Regex =
+            Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
+        for m in cpp_main_regex.captures_iter(&self.input) {
+            if m.name("main").is_some() {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/src/boilerplate/generator.rs
+++ b/src/boilerplate/generator.rs
@@ -1,0 +1,61 @@
+use crate::boilerplate::cpp::CppGenerator;
+use crate::boilerplate::csharp::CSharpGenerator;
+use crate::boilerplate::java::JavaGenerator;
+
+pub trait BoilerPlateGenerator {
+    fn new(input: &str) -> Self
+    where
+        Self: Sized;
+    fn generate(&self) -> String;
+    fn needs_boilerplate(&self) -> bool;
+}
+
+pub struct BoilerPlate<T: ?Sized>
+where
+    T: BoilerPlateGenerator,
+{
+    generator: Box<T>,
+}
+
+impl<T: ?Sized> BoilerPlate<T>
+where
+    T: BoilerPlateGenerator,
+{
+    pub fn new(generator: Box<T>) -> Self {
+        Self { generator }
+    }
+
+    pub fn generate(&self) -> String {
+        self.generator.generate()
+    }
+
+    pub fn needs_boilerplate(&self) -> bool {
+        self.generator.needs_boilerplate()
+    }
+}
+
+pub struct Null;
+impl BoilerPlateGenerator for Null {
+    fn new(_: &str) -> Self {
+        Self {}
+    }
+
+    fn generate(&self) -> String {
+        panic!("Cannot generate null boilerplate!");
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        false
+    }
+}
+
+pub fn boilerplate_factory(language: &str, code: &str) -> BoilerPlate<dyn BoilerPlateGenerator> {
+    match language {
+        "c++" | "c" => BoilerPlate::new(Box::new(CppGenerator::new(code))),
+        "java" => BoilerPlate::new(Box::new(JavaGenerator::new(code))),
+        "c#" => BoilerPlate::new(Box::new(CSharpGenerator::new(code))),
+        // since all compilations go through this path, we have a Null generator whose
+        // needs_boilerplate() always returns false.
+        _ => BoilerPlate::new(Box::new(Null::new(code))),
+    }
+}

--- a/src/boilerplate/java.rs
+++ b/src/boilerplate/java.rs
@@ -1,0 +1,47 @@
+use crate::boilerplate::generator::BoilerPlateGenerator;
+use regex::Regex;
+
+pub struct JavaGenerator {
+    input: String,
+}
+
+impl BoilerPlateGenerator for JavaGenerator {
+    fn new(input: &str) -> Self {
+        let mut formated = input.to_string();
+        formated = formated.replace(';', ";\n"); // separate lines by ;
+
+        Self { input: formated }
+    }
+
+    fn generate(&self) -> String {
+        let mut main_body = String::default();
+        let mut header = String::default();
+
+        let lines = self.input.split('\n');
+        for line in lines {
+            let trimmed = line.trim();
+            if trimmed.starts_with("import") {
+                header.push_str(&format!("{}\n", trimmed));
+            } else {
+                main_body.push_str(&format!("{}\n", trimmed))
+            }
+        }
+
+        format!(
+            "{}\nclass Main{{\npublic static void main(String[] args) {{\n{}}}}}",
+            header, main_body
+        )
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        let java_main_regex: Regex =
+            Regex::new("\"[^\"]+\"|(?P<main>public[\\s]+?static[\\s]+?void[\\s]+?main[\\s]*?\\()")
+                .unwrap();
+        for m in java_main_regex.captures_iter(&self.input) {
+            if m.name("main").is_some() {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/src/boilerplate/mod.rs
+++ b/src/boilerplate/mod.rs
@@ -1,0 +1,4 @@
+pub mod cpp;
+pub mod csharp;
+pub mod generator;
+pub mod java;

--- a/src/events.rs
+++ b/src/events.rs
@@ -282,13 +282,16 @@ impl EventHandler for Handler {
             }
         }
 
-        tokio::task::spawn(async move {
-            let ctx = ctx.clone();
-            let data = ctx.data.read().await;
-            let cmd_mgr = data.get::<CommandCache>().unwrap().read().await;
-            cmd_mgr.register_commands(&ctx).await;
-            info!("[Shard {}] Registered commands", ctx.shard_id);
-        });
+        // tokio::task::spawn(async move {
+        //     let ctx = ctx.clone();
+        //     let data = ctx.data.read().await;
+        //     let cmd_mgr = data.get::<CommandCache>().unwrap().read().await;
+        //     cmd_mgr.register_commands(&ctx).await;
+        //     info!("[Shard {}] Registered commands", ctx.shard_id);
+        // });
+        let data = ctx.data.read().await;
+        let mut cmd_mgr = data.get::<CommandCache>().unwrap().write().await;
+        cmd_mgr.register_commands(&ctx).await;
     }
 
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![type_length_limit = "1146253"]
 
 mod apis;
+mod boilerplate;
 mod cache;
 mod commands;
 mod cppeval;

--- a/src/managers/command.rs
+++ b/src/managers/command.rs
@@ -10,11 +10,15 @@ use serenity::{
 };
 use std::collections::HashMap;
 
-pub struct CommandManager;
+pub struct CommandManager {
+    command_registered: bool,
+}
 
 impl CommandManager {
     pub fn new() -> Self {
-        CommandManager {}
+        CommandManager {
+            command_registered: false,
+        }
     }
 
     pub async fn on_command(
@@ -49,7 +53,12 @@ impl CommandManager {
         }
     }
 
-    pub async fn register_commands(&self, ctx: &Context) {
+    pub async fn register_commands(&mut self, ctx: &Context) {
+        if self.command_registered {
+            return;
+        }
+        self.command_registered = true;
+
         let data_read = ctx.data.read().await;
         let compiler_cache = data_read.get::<CompilerCache>().unwrap();
         let compiler_manager = compiler_cache.read().await;
@@ -105,5 +114,6 @@ impl CommandManager {
         {
             error!("Unable to create application commands: {}", err);
         }
+        info!("Registered application commands");
     }
 }

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -4,6 +4,7 @@ use serenity::builder::CreateEmbed;
 use serenity::framework::standard::CommandError;
 use serenity::model::user::User;
 
+use crate::boilerplate::generator::boilerplate_factory;
 use godbolt::{CompilationFilters, CompilerOptions, Godbolt, GodboltError, RequestOptions};
 use wandbox::{CompilationBuilder, Wandbox, WandboxError};
 
@@ -112,7 +113,7 @@ impl CompilationManager {
         let resolution_result = self.gbolt.resolve(target);
         return match resolution_result {
             None => {
-                Err(CommandError::from(format!("Target '{}' either does not produce assembly or is not currently supported on Azure", target)))
+                Err(CommandError::from(format!("Target '{}' either does not produce assembly or is not currently supported on godbolt.org", target)))
             }
             Some(compiler) => {
                 let response = Godbolt::send_request(&compiler, &parse_result.code, options, USER_AGENT).await?;
@@ -156,8 +157,16 @@ impl CompilationManager {
             &parse_result.target
         };
         let compiler = self.gbolt.resolve(target).unwrap();
-        let response =
-            Godbolt::send_request(&compiler, &parse_result.code, options, USER_AGENT).await?;
+
+        // replace boilerplate code if needed
+        let mut code = parse_result.code.clone();
+        {
+            let generator = boilerplate_factory(&compiler.lang, &code);
+            if generator.needs_boilerplate() {
+                code = generator.generate();
+            }
+        }
+        let response = Godbolt::send_request(&compiler, &code, options, USER_AGENT).await?;
         Ok((compiler.lang, response))
     }
 
@@ -179,8 +188,33 @@ impl CompilationManager {
         &self,
         parse_result: &ParserResult,
     ) -> Result<(String, wandbox::CompilationResult), WandboxError> {
+        let lang = {
+            let mut found = String::default();
+            for lang in self.wbox.get_languages() {
+                if parse_result.target == lang.name {
+                    found = parse_result.target.clone();
+                }
+                for compiler in lang.compilers {
+                    if compiler.name == parse_result.target {
+                        found = lang.name.clone();
+                    }
+                }
+            }
+            if found.is_empty() {
+                warn!("Invalid target leaked checks and was caught before boilerplate creation")
+            }
+            found
+        };
+        let mut code = parse_result.code.clone();
+        {
+            let generator = boilerplate_factory(&lang, &code);
+            if generator.needs_boilerplate() {
+                code = generator.generate();
+            }
+        }
+
         let mut builder = CompilationBuilder::new();
-        builder.code(&parse_result.code);
+        builder.code(&code);
         builder.target(&parse_result.target);
         builder.stdin(&parse_result.stdin);
         builder.save(false);

--- a/src/tests/cpp.rs
+++ b/src/tests/cpp.rs
@@ -66,6 +66,6 @@ async fn eval_output_balance() {
     let mut eval = CppEval::new("{ /* {{{ */ }");
     if let Err(e) = eval.evaluate() {
         println!("{}", e);
-        assert!(false, "Parser failed")
+        panic!("Parser failed")
     }
 }

--- a/src/tests/parser.rs
+++ b/src/tests/parser.rs
@@ -18,7 +18,7 @@ async fn standard_parse() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -43,7 +43,7 @@ async fn standard_parse_args() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -63,7 +63,7 @@ async fn standard_parse_url_args() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -84,7 +84,7 @@ async fn standard_parse_url() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -109,7 +109,7 @@ async fn standard_parse_stdin() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -137,7 +137,7 @@ async fn standard_parse_block_stdin() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -163,7 +163,7 @@ async fn standard_parse_deduce_compiler() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -189,7 +189,7 @@ async fn standard_parse_deduce_compiler_upper_case() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -215,7 +215,7 @@ async fn standard_parse_late_deduce_compiler() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -244,7 +244,7 @@ async fn standard_parse_late_deduce_compiler_block_stdin() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -265,7 +265,7 @@ async fn standard_parse_one_line() {
     let cm = Arc::new(RwLock::new(CompilationManager::new().await.unwrap()));
     let result = get_components(input, &dummy_user, Some(&cm), &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();
@@ -285,7 +285,7 @@ async fn standard_parse_args_one_line() {
     let reply = None;
     let result = get_components(input, &dummy_user, None, &reply).await;
     if result.is_err() {
-        assert!(false, "Parser failed.");
+        panic!("Parser failed.");
     }
 
     let parser_result = result.unwrap();

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -10,8 +10,8 @@ pub const ICON_HELP: &str = "https://i.imgur.com/TNzxfMB.png";
 pub const ICON_INVITE: &str = "https://i.imgur.com/CZFt69d.png";
 //pub const COMPILER_EXPLORER_ICON: &str = "https://i.imgur.com/GIgATFr.png";
 pub const COMPILER_ICON: &str = "http://i.michaelwflaherty.com/u/XedLoQWCVc.png";
-pub const MAX_OUTPUT_LEN: usize = 450;
-pub const MAX_ERROR_LEN: usize = 950;
+pub const MAX_OUTPUT_LEN: usize = 250;
+pub const MAX_ERROR_LEN: usize = 956;
 pub const USER_AGENT: &str =
     const_format::formatcp!("discord-compiler-bot/{}", env!("CARGO_PKG_VERSION"));
 pub const URL_ALLOW_LIST: [&str; 4] = [

--- a/src/utls/discordhelpers/embeds.rs
+++ b/src/utls/discordhelpers/embeds.rs
@@ -135,13 +135,13 @@ impl ToEmbed<bool> for godbolt::GodboltResponse {
             let stderr = errs.trim();
             let mut output = false;
             if !stdout.is_empty() {
-                let str = discordhelpers::conform_external_str(stdout, MAX_ERROR_LEN);
+                let str = discordhelpers::conform_external_str(stdout, MAX_OUTPUT_LEN);
                 embed.field("Program Output", format!("```\n{}\n```", str), false);
                 output = true;
             }
             if !stderr.is_empty() {
                 output = true;
-                let str = discordhelpers::conform_external_str(stderr, MAX_OUTPUT_LEN);
+                let str = discordhelpers::conform_external_str(stderr, MAX_ERROR_LEN);
                 embed.field("Compiler Output", format!("```\n{}\n```", str), false);
             }
 


### PR DESCRIPTION
We only need to register shard once for every guilds (which speed up setup).
Stdout and stderr output length were mixed.