### PR TITLE
improve boilerplate implementation

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,0 +1,5 @@
+[hooks]
+pre-commit = "cargo fmt && cargo clippy --all-targets --all-features -- -D clippy::all && cargo test"
+
+[logging]
+verbose = true 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "discord-compiler-bot"
 description = "Discord bot to compile your spaghetti code."
-version = "0.1.2"
+version = "0.1.3"
 authors = ["ThomasByr"]
 edition = "2021"
 build = "src/build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["ThomasByr"]
 edition = "2021"
 build = "src/build.rs"
 
+[dev-dependencies]
+rusty-hook = "0.11.2"
+
 [dependencies]
 # openssl = { version = "0.10", features = ["vendored"] }
 tokio = { version = "1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1"
 content_inspector = "0.2"
 shell-words = "0.1"
 const_format = "0.2"
+lazy_static = "1.4.0"
 #tests
 indoc = "1.0.3"
 test-context = "0.1"

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ int main(int argc, char** argv) {
 ```
 ````
 
-1. [In short](#in-short)
-2. [Usage](#usage)
-3. [Get Help](#get-help)
-4. [Support](#support)
-5. [License](#license)
-6. [Changelog, Bugs and TODO](#changelog-bugs-and-todo)
+1. [✏️ In short](#️-in-short)
+2. [👩‍🏫 Usage](#-usage)
+3. [💁 Get Help](#-get-help)
+4. [🔰 Support](#-support)
+5. [⚖️ License](#️-license)
+6. [🔄 Changelog, Bugs and TODO](#-changelog-bugs-and-todo)
 
-## In short
+## ✏️ In short
 
 First, this project was done in a week so do not expect crazy behavior and be immune to bugs.
 
@@ -53,7 +53,7 @@ This is a Discord compiler bot which can compile / interpret code blocks and dis
 
 Please read [the Wiki](https://github.com/ThomasByr/discord-compiler-bot/wiki) for more.
 
-## Usage
+## 👩‍🏫 Usage
 
 First you should install the [Rust programming language](https://www.rust-lang.org/learn/get-started) for your operating system. Then, you should create a new `.env` file on the model of the `.env.example`. You should at least set `BOT_TOKEN` and `APPLICATION_ID` (you can let other fields untouched) environnement variables.
 
@@ -63,7 +63,7 @@ cargo run --release
 
 The bot should then connect to the servers and if succesfull, show a list of debug commands on the go.
 
-## Get Help
+## 💁 Get Help
 
 While in discord, please type `;help` to get generic help and show a list of available commands, or type `;help <cmd>` to get help about a specific command. Here is a list of the most usefull ones.
 
@@ -74,13 +74,13 @@ While in discord, please type `;help` to get generic help and show a list of ava
 
 If you want to contribute, please read the [contributing](.github/CONTRIBUTING.md) guideline, make pull requests and be kind.
 
-## Support
+## 🔰 Support
 
 Support for following languages : c++, c, java, python, ruby, rust, javascript, go, php, lua and many more.
 
 > [Create a new issue](https://github.com/ThomasByr/discord-compiler-bot/issues/new)
 
-## License
+## ⚖️ License
 
 This project is licensed under the GPL-3.0 new or revised license. Please read the [LICENSE](LICENSE) file.
 
@@ -92,7 +92,7 @@ This project is licensed under the GPL-3.0 new or revised license. Please read t
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-## Changelog, Bugs and TODO
+## 🔄 Changelog, Bugs and TODO
 
 <details>
     <summary>  Beta first minor release (click here to expand) </summary>

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 - `;block` and `;unblock` commands working (blacklist)
 - added boilerplate code for some languages
 
+**v0.1.3** local rights and corrections
+
+- patched boilerplate code gen for java
+- c detached from c++ boilerplate
+- created alternate server count
+
 </details>
 
 **TODO** (first implementation version)

--- a/changelog.md
+++ b/changelog.md
@@ -26,3 +26,9 @@
 - deactivated local execution for some guilds
 - `;block` and `;unblock` commands working (blacklist)
 - added boilerplate code for some languages
+
+**v0.1.3** local rights and corrections
+
+- patched boilerplate code gen for java
+- c detached from c++ boilerplate
+- created alternate server count

--- a/src/boilerplate/c.rs
+++ b/src/boilerplate/c.rs
@@ -1,4 +1,5 @@
 use crate::boilerplate::generator::BoilerPlateGenerator;
+
 use crate::utls::constants::C_LIKE_MAIN_REGEX;
 
 pub struct CGenerator {

--- a/src/boilerplate/c.rs
+++ b/src/boilerplate/c.rs
@@ -1,12 +1,11 @@
 use crate::boilerplate::generator::BoilerPlateGenerator;
-
 use crate::utls::constants::C_LIKE_MAIN_REGEX;
 
-pub struct CppGenerator {
+pub struct CGenerator {
     input: String,
 }
 
-impl BoilerPlateGenerator for CppGenerator {
+impl BoilerPlateGenerator for CGenerator {
     fn new(input: &str) -> Self {
         let mut formated = input.to_string();
         formated = formated.replace(';', ";\n"); // separate lines by ;
@@ -28,9 +27,8 @@ impl BoilerPlateGenerator for CppGenerator {
             }
         }
 
-        // if they included nothing, we can just manually include everything
-        if !header.contains("#include") {
-            header.push_str("#include <bits/stdc++.h>");
+        if main_body.contains("printf") && header.contains("stdio.h") {
+            header.push_str("include <stdio.h>")
         }
         format!("{}\nint main(void) {{\n{}return 0;\n}}", header, main_body)
     }

--- a/src/boilerplate/csharp.rs
+++ b/src/boilerplate/csharp.rs
@@ -1,5 +1,6 @@
 use crate::boilerplate::generator::BoilerPlateGenerator;
-use regex::Regex;
+
+use crate::utls::constants::CSHARP_MAIN_REGEX;
 
 pub struct CSharpGenerator {
     input: String,
@@ -38,9 +39,7 @@ impl BoilerPlateGenerator for CSharpGenerator {
     }
 
     fn needs_boilerplate(&self) -> bool {
-        let cpp_main_regex: Regex =
-            Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
-        for m in cpp_main_regex.captures_iter(&self.input) {
+        for m in CSHARP_MAIN_REGEX.captures_iter(&self.input) {
             if m.name("main").is_some() {
                 return false;
             }

--- a/src/boilerplate/generator.rs
+++ b/src/boilerplate/generator.rs
@@ -1,3 +1,4 @@
+use crate::boilerplate::c::CGenerator;
 use crate::boilerplate::cpp::CppGenerator;
 use crate::boilerplate::csharp::CSharpGenerator;
 use crate::boilerplate::java::JavaGenerator;
@@ -51,7 +52,8 @@ impl BoilerPlateGenerator for Null {
 
 pub fn boilerplate_factory(language: &str, code: &str) -> BoilerPlate<dyn BoilerPlateGenerator> {
     match language {
-        "c++" | "c" => BoilerPlate::new(Box::new(CppGenerator::new(code))),
+        "c++" => BoilerPlate::new(Box::new(CppGenerator::new(code))),
+        "c" => BoilerPlate::new(Box::new(CGenerator::new(code))),
         "java" => BoilerPlate::new(Box::new(JavaGenerator::new(code))),
         "c#" => BoilerPlate::new(Box::new(CSharpGenerator::new(code))),
         // since all compilations go through this path, we have a Null generator whose

--- a/src/boilerplate/java.rs
+++ b/src/boilerplate/java.rs
@@ -1,5 +1,6 @@
 use crate::boilerplate::generator::BoilerPlateGenerator;
-use regex::Regex;
+
+use crate::utls::constants::JAVA_MAIN_REGEX;
 
 pub struct JavaGenerator {
     input: String,
@@ -34,10 +35,7 @@ impl BoilerPlateGenerator for JavaGenerator {
     }
 
     fn needs_boilerplate(&self) -> bool {
-        let java_main_regex: Regex =
-            Regex::new("\"[^\"]+\"|(?P<main>public[\\s]+?static[\\s]+?void[\\s]+?main[\\s]*?\\()")
-                .unwrap();
-        for m in java_main_regex.captures_iter(&self.input) {
+        for m in JAVA_MAIN_REGEX.captures_iter(&self.input) {
             if m.name("main").is_some() {
                 return false;
             }

--- a/src/boilerplate/mod.rs
+++ b/src/boilerplate/mod.rs
@@ -1,3 +1,4 @@
+pub mod c;
 pub mod cpp;
 pub mod csharp;
 pub mod generator;

--- a/src/commands/asm.rs
+++ b/src/commands/asm.rs
@@ -78,7 +78,11 @@ pub async fn handle_request(
         };
 
     // send out loading emote
-    if msg.react(&ctx.http, loading_reaction.clone()).await.is_err() {
+    if msg
+        .react(&ctx.http, loading_reaction.clone())
+        .await
+        .is_err()
+    {
         return Err(CommandError::from("Unable to react to message, am I missing permissions to react or use external emoji?\n{}"));
     }
 

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -82,7 +82,11 @@ pub async fn handle_request(
     .await?;
 
     // send out loading emote
-    if msg.react(&ctx.http, loading_reaction.clone()).await.is_err() {
+    if msg
+        .react(&ctx.http, loading_reaction.clone())
+        .await
+        .is_err()
+    {
         return Err(CommandError::from("Unable to react to message, am I missing permissions to react or use external emoji?\n{}"));
     }
 

--- a/src/commands/cpp.rs
+++ b/src/commands/cpp.rs
@@ -68,7 +68,11 @@ pub async fn handle_request(
     let out = eval.evaluate()?;
 
     // send out loading emote
-    if msg.react(&ctx.http, loading_reaction.clone()).await.is_err() {
+    if msg
+        .react(&ctx.http, loading_reaction.clone())
+        .await
+        .is_err()
+    {
         return Err(CommandError::from("Unable to react to message, am I missing permissions to react or use external emoji?\n{}"));
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -171,7 +171,11 @@ impl EventHandler for Handler {
                         }
                     };
 
-                    if new_message.react(&ctx.http, reaction.clone()).await.is_err() {
+                    if new_message
+                        .react(&ctx.http, reaction.clone())
+                        .await
+                        .is_err()
+                    {
                         return;
                     }
 
@@ -305,7 +309,9 @@ impl EventHandler for Handler {
                     // send an edit, and if that fails we'll pivot to create a new interaction
                     // response
                     let fail_embed = embeds::build_fail_embed(&command.user, &e.to_string());
-                    if send_error_msg(&ctx, &command, false, fail_embed.clone()).await.is_err()
+                    if send_error_msg(&ctx, &command, false, fail_embed.clone())
+                        .await
+                        .is_err()
                     {
                         warn!("Sending new integration for error: {}", e);
                         let _ = send_error_msg(&ctx, &command, true, fail_embed.clone()).await;

--- a/src/managers/compilation.rs
+++ b/src/managers/compilation.rs
@@ -8,7 +8,7 @@ use crate::boilerplate::generator::boilerplate_factory;
 use godbolt::{CompilationFilters, CompilerOptions, Godbolt, GodboltError, RequestOptions};
 use wandbox::{CompilationBuilder, Wandbox, WandboxError};
 
-use crate::utls::constants::USER_AGENT;
+use crate::utls::constants::{JAVA_PUBLIC_CLASS_REGEX, USER_AGENT};
 use crate::utls::discordhelpers::embeds::ToEmbed;
 use crate::utls::parser::ParserResult;
 
@@ -158,13 +158,14 @@ impl CompilationManager {
         };
         let compiler = self.gbolt.resolve(target).unwrap();
 
-        // replace boilerplate code if needed
+        // add boilerplate code if needed & fix common mistakes
         let mut code = parse_result.code.clone();
         {
             let generator = boilerplate_factory(&compiler.lang, &code);
             if generator.needs_boilerplate() {
                 code = generator.generate();
             }
+            code = fix_common_problems(&compiler.lang, code);
         }
         let response = Godbolt::send_request(&compiler, &code, options, USER_AGENT).await?;
         Ok((compiler.lang, response))
@@ -211,6 +212,7 @@ impl CompilationManager {
             if generator.needs_boilerplate() {
                 code = generator.generate();
             }
+            code = fix_common_problems(&lang, code);
         }
 
         let mut builder = CompilationBuilder::new();
@@ -243,4 +245,20 @@ impl CompilationManager {
     pub fn slash_cmd_langs_asm() -> [&'static str; 7] {
         ["C++", "C", "Haskell", "Java", "Python", "Rust", "Zig"]
     }
+}
+
+fn fix_common_problems(language: &str, code: String) -> String {
+    return match language {
+        "java" => {
+            // Fix compilations that
+            let mut fix_candidate = code.clone();
+            for m in JAVA_PUBLIC_CLASS_REGEX.captures_iter(&code) {
+                if let Some(pub_keyword) = m.name("public") {
+                    fix_candidate.replace_range(pub_keyword.range(), "")
+                }
+            }
+            fix_candidate
+        }
+        _ => code,
+    };
 }

--- a/src/slashcmds/format.rs
+++ b/src/slashcmds/format.rs
@@ -15,7 +15,7 @@ use serenity::{
 use std::time::Duration;
 
 pub async fn format(ctx: &Context, command: &ApplicationCommandInteraction) -> CommandResult {
-    // let mut msg = None;
+    let mut msg = None;
     let mut parse_result = ParserResult::default();
 
     // for (_, value) in &command.data.resolved.messages {
@@ -26,15 +26,12 @@ pub async fn format(ctx: &Context, command: &ApplicationCommandInteraction) -> C
     //     break;
     // }
 
-    if command.data.resolved.messages.is_empty() {
-        return Err(CommandError::from("Unable to find a codeblock to format!"));
+    if let Some((_, value)) = command.data.resolved.messages.iter().next() {
+        if !parser::find_code_block(&mut parse_result, &value.content, &command.user).await? {
+            return Err(CommandError::from("Unable to find a codeblock to format!"));
+        }
+        msg = Some(value);
     }
-
-    let value = command.data.resolved.messages.values().next().unwrap();
-    if !parser::find_code_block(&mut parse_result, &value.content, &command.user).await? {
-        return Err(CommandError::from("Unable to find a codeblock to format!"));
-    }
-    let msg = Some(value);
 
     let data = ctx.data.read().await;
     let comp_mgr = data.get::<CompilerCache>().unwrap().read().await;

--- a/src/tests/boilerplate/cpp.rs
+++ b/src/tests/boilerplate/cpp.rs
@@ -1,0 +1,51 @@
+#[cfg(test)]
+
+use crate::boilerplate::cpp::CppGenerator;
+use crate::boilerplate::generator::BoilerPlateGenerator;
+
+#[tokio::test]
+async fn standard_needs_boilerplate() {
+    let gen = CppGenerator::new("std::string str = \"test\";\n\
+    std::cout << str;");
+    assert!(gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate() {
+    let gen = CppGenerator::new("int main() {\n\
+    std::string str = \"test\";\n\
+    std::cout << str;\n\
+    return 0;\n\
+    }");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate2() {
+    let gen = CppGenerator::new("int main (    ) {\n\
+    std::string str = \"test\";\n\
+    std::cout << str;\n\
+    return 0;\n\
+    }");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate3() {
+    let gen = CppGenerator::new("int main\n(void) {\n\
+    std::string str = \"test\";\n\
+    std::cout << str;\n\
+    return 0;\n\
+    }");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate4() {
+    let gen = CppGenerator::new("void main    (void) {\n\
+    std::string str = \"test\";\n\
+    std::cout << str;\n\
+    return 0;\n\
+    }");
+    assert!(!gen.needs_boilerplate());
+}

--- a/src/tests/boilerplate/cpp.rs
+++ b/src/tests/boilerplate/cpp.rs
@@ -1,51 +1,60 @@
 #[cfg(test)]
-
 use crate::boilerplate::cpp::CppGenerator;
 use crate::boilerplate::generator::BoilerPlateGenerator;
 
 #[tokio::test]
 async fn standard_needs_boilerplate() {
-    let gen = CppGenerator::new("std::string str = \"test\";\n\
-    std::cout << str;");
+    let gen = CppGenerator::new(
+        "std::string str = \"test\";\n\
+    std::cout << str;",
+    );
     assert!(gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate() {
-    let gen = CppGenerator::new("int main() {\n\
+    let gen = CppGenerator::new(
+        "int main() {\n\
     std::string str = \"test\";\n\
     std::cout << str;\n\
     return 0;\n\
-    }");
+    }",
+    );
     assert!(!gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate2() {
-    let gen = CppGenerator::new("int main (    ) {\n\
+    let gen = CppGenerator::new(
+        "int main (    ) {\n\
     std::string str = \"test\";\n\
     std::cout << str;\n\
     return 0;\n\
-    }");
+    }",
+    );
     assert!(!gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate3() {
-    let gen = CppGenerator::new("int main\n(void) {\n\
+    let gen = CppGenerator::new(
+        "int main\n(void) {\n\
     std::string str = \"test\";\n\
     std::cout << str;\n\
     return 0;\n\
-    }");
+    }",
+    );
     assert!(!gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate4() {
-    let gen = CppGenerator::new("void main    (void) {\n\
+    let gen = CppGenerator::new(
+        "void main    (void) {\n\
     std::string str = \"test\";\n\
     std::cout << str;\n\
     return 0;\n\
-    }");
+    }",
+    );
     assert!(!gen.needs_boilerplate());
 }

--- a/src/tests/boilerplate/java.rs
+++ b/src/tests/boilerplate/java.rs
@@ -1,0 +1,47 @@
+#[cfg(test)]
+
+use crate::boilerplate::java::JavaGenerator;
+use crate::boilerplate::generator::BoilerPlateGenerator;
+
+#[tokio::test]
+async fn standard_needs_boilerplate() {
+    let gen = JavaGenerator::new("String str = \"test\";\n\
+    System.out.println(str)");
+    assert!(gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static void main(String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate2() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static void main (String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate3() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static void main\t(String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate4() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static void main                               (String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+}

--- a/src/tests/boilerplate/java.rs
+++ b/src/tests/boilerplate/java.rs
@@ -1,56 +1,67 @@
-#[cfg(test)]
-
-use crate::boilerplate::java::JavaGenerator;
 use crate::boilerplate::generator::BoilerPlateGenerator;
+#[cfg(test)]
+use crate::boilerplate::java::JavaGenerator;
 
 #[tokio::test]
 async fn standard_needs_boilerplate() {
-    let gen = JavaGenerator::new("String str = \"test\";\n\
-    System.out.println(str)");
+    let gen = JavaGenerator::new(
+        "String str = \"test\";\n\
+    System.out.println(str)",
+    );
     assert!(gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate() {
-    let gen = JavaGenerator::new("class Test {\n\
+    let gen = JavaGenerator::new(
+        "class Test {\n\
     public static void main(String[] args) {\n\
     }\n\
-    }\n");
+    }\n",
+    );
     assert!(!gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate2() {
-    let gen = JavaGenerator::new("class Test {\n\
+    let gen = JavaGenerator::new(
+        "class Test {\n\
     public static void main (String[] args) {\n\
     }\n\
-    }\n");
+    }\n",
+    );
     assert!(!gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate3() {
-    let gen = JavaGenerator::new("class Test {\n\
+    let gen = JavaGenerator::new(
+        "class Test {\n\
     public static void main\t(String[] args) {\n\
     }\n\
-    }\n");
+    }\n",
+    );
     assert!(!gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate4() {
-    let gen = JavaGenerator::new("class Test {\n\
+    let gen = JavaGenerator::new(
+        "class Test {\n\
     public static void main                               (String[] args) {\n\
     }\n\
-    }\n");
+    }\n",
+    );
     assert!(!gen.needs_boilerplate());
 }
 
 #[tokio::test]
 async fn standard_doesnt_need_boilerplate5() {
-    let gen = JavaGenerator::new("class Test {\n\
+    let gen = JavaGenerator::new(
+        "class Test {\n\
     public static final void main                               (String[] args) {\n\
     }\n\
-    }\n");
+    }\n",
+    );
     assert!(!gen.needs_boilerplate());
-} 
+}

--- a/src/tests/boilerplate/java.rs
+++ b/src/tests/boilerplate/java.rs
@@ -45,3 +45,12 @@ async fn standard_doesnt_need_boilerplate4() {
     }\n");
     assert!(!gen.needs_boilerplate());
 }
+
+#[tokio::test]
+async fn standard_doesnt_need_boilerplate5() {
+    let gen = JavaGenerator::new("class Test {\n\
+    public static final void main                               (String[] args) {\n\
+    }\n\
+    }\n");
+    assert!(!gen.needs_boilerplate());
+} 

--- a/src/tests/boilerplate/mod.rs
+++ b/src/tests/boilerplate/mod.rs
@@ -1,0 +1,4 @@
+#[cfg(test)]
+pub mod cpp;
+#[cfg(test)]
+pub mod java;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,4 @@
-#[cfg(test)]
-
-pub mod parser;
-pub mod cpp;
 pub mod boilerplate;
+pub mod cpp;
+#[cfg(test)]
+pub mod parser;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,5 @@
-pub mod cpp;
 #[cfg(test)]
+
 pub mod parser;
+pub mod cpp;
+pub mod boilerplate;

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -27,8 +27,7 @@ pub const URL_ALLOW_LIST: [&str; 4] = [
 // Boilerplate Regexes
 lazy_static! {
     pub static ref JAVA_MAIN_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<main>public[\\s]+?static[\\s]+?void[\\s]+?main[\\s]*?\\()")
-            .unwrap();
+        Regex::new("\"[^\"]+\"|(?P<main>void[\\s]+?main[\\s]*?\\()").unwrap();
     pub static ref C_LIKE_MAIN_REGEX: Regex =
         Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
     pub static ref CSHARP_MAIN_REGEX: Regex =

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -1,3 +1,6 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+
 //pub const COLOR_OKAY : i32 = 0x046604;
 pub const COLOR_OKAY: u32 = 0x5dbcd2;
 //pub const COLOR_FAIL : i32 = 0x660404;
@@ -20,6 +23,17 @@ pub const URL_ALLOW_LIST: [&str; 4] = [
     "hastebin.com",
     "raw.githubusercontent.com",
 ];
+
+// Boilerplate Regexes
+lazy_static! {
+    pub static ref JAVA_MAIN_REGEX: Regex =
+        Regex::new("\"[^\"]+\"|(?P<main>public[\\s]+?static[\\s]+?void[\\s]+?main[\\s]*?\\()")
+            .unwrap();
+    pub static ref C_LIKE_MAIN_REGEX: Regex =
+        Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
+    pub static ref CSHARP_MAIN_REGEX: Regex =
+        Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
+}
 
 /*
    Discord limits the size of the amount of compilers we can display to users, for some languages

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -34,6 +34,12 @@ lazy_static! {
         Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
 }
 
+// Other Regexes
+lazy_static! {
+    pub static ref JAVA_PUBLIC_CLASS_REGEX: Regex =
+        Regex::new("\"[^\"]+\"|(?P<public>public)[\\s]+?class[\\s]*?").unwrap();
+}
+
 /*
    Discord limits the size of the amount of compilers we can display to users, for some languages
    we'll just grab the first 25 from our API, for C & C++ we will create a curated list manually.

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -263,8 +263,16 @@ pub async fn manual_dispatch(http: Arc<Http>, id: u64, emb: CreateEmbed) {
 }
 
 pub async fn send_global_presence(shard_manager: &MutexGuard<'_, ShardManager>, sum: u64) {
+    let server_count = {
+        if sum < 10000 {
+            sum.to_string()
+        } else {
+            format!("{:.1}k", sum / 1000)
+        }
+    };
+
     // update shard guild count & presence
-    let presence_str = format!("in {} servers | ;invite", sum);
+    let presence_str = format!("in {} servers | ;invite", server_count);
 
     let runners = shard_manager.runners.lock().await;
     for (_, v) in runners.iter() {

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -51,7 +51,7 @@ pub async fn get_components(
     }
     if let Some(index) = input.find('`') {
         if end_point == 0 || index < end_point {
-        // if the ` character is found before \n we should use the ` as our parse stop point
+            // if the ` character is found before \n we should use the ` as our parse stop point
             end_point = index;
         }
     }

--- a/src/utls/parser.rs
+++ b/src/utls/parser.rs
@@ -180,7 +180,6 @@ pub async fn get_components(
         return Err(CommandError::from("You must provide a valid language or compiler!\n\n;compile c++ \n\\`\\`\\`\nint main() {}\n\\`\\`\\`"));
     }
 
-    //println!("Parse object: {:?}", result);
     Ok(result)
 }
 


### PR DESCRIPTION
This is an extension to the boilerplate implementation, we'll see a few things developed on this branch.

This patch will move some of the regex creation to be in the constants.rs and prevent regex recompilation after every compilation request, something that we needed to bring lazy_static in to accomplish.

Our end goal is to move function declarations out of main methods, that way functions can be created and moved to their correct places as needed.

We'll need a regex made that allows us to detect function definitions. Unlike our main regexes, we'd need to match functions that could have templated/generic return types. Let's use C++ as an example.

```cpp
std::vector < int > myfunc(int a, int b) {
    return std::vector{a, b};
}
for (auto i : myfunc(3, 5)) {
    std::cout << i << std::endl;
}
```

A request in this form should not trip up our detection, so correctly matching any function call regardless of it's return type form might be tricky, we'll have to see.