### PR TITLE
Implement command to allow diffing code-blocks

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,5 +1,5 @@
 [hooks]
-pre-commit = "cargo fmt && cargo clippy --all-targets --all-features -- -D clippy::all && cargo test"
+pre-commit = "cargo fmt -- --check && cargo clippy --all-targets --all-features -- -D clippy::all && cargo test"
 
 [logging]
 verbose = true 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ content_inspector = "0.2"
 shell-words = "0.1"
 const_format = "0.2"
 lazy_static = "1.4.0"
+similar = "2.1.0"
 #tests
 indoc = "1.0.3"
 test-context = "0.1"

--- a/src/boilerplate/generator.rs
+++ b/src/boilerplate/generator.rs
@@ -1,7 +1,7 @@
-use crate::boilerplate::c::CGenerator;
-use crate::boilerplate::cpp::CppGenerator;
-use crate::boilerplate::csharp::CSharpGenerator;
-use crate::boilerplate::java::JavaGenerator;
+use crate::boilerplate::{
+    c::CGenerator, cpp::CppGenerator, csharp::CSharpGenerator, java::JavaGenerator,
+    php::PHPGenerator,
+};
 
 pub trait BoilerPlateGenerator {
     fn new(input: &str) -> Self
@@ -56,6 +56,7 @@ pub fn boilerplate_factory(language: &str, code: &str) -> BoilerPlate<dyn Boiler
         "c" => BoilerPlate::new(Box::new(CGenerator::new(code))),
         "java" => BoilerPlate::new(Box::new(JavaGenerator::new(code))),
         "c#" => BoilerPlate::new(Box::new(CSharpGenerator::new(code))),
+        "php" => BoilerPlate::new(Box::new(PHPGenerator::new(code))),
         // since all compilations go through this path, we have a Null generator whose
         // needs_boilerplate() always returns false.
         _ => BoilerPlate::new(Box::new(Null::new(code))),

--- a/src/boilerplate/mod.rs
+++ b/src/boilerplate/mod.rs
@@ -3,3 +3,4 @@ pub mod cpp;
 pub mod csharp;
 pub mod generator;
 pub mod java;
+pub mod php;

--- a/src/boilerplate/php.rs
+++ b/src/boilerplate/php.rs
@@ -1,0 +1,28 @@
+use crate::boilerplate::generator::BoilerPlateGenerator;
+use crate::utls::constants::PHP_START_REGEX;
+
+pub struct PHPGenerator {
+    input: String,
+}
+
+impl BoilerPlateGenerator for PHPGenerator {
+    fn new(input: &str) -> Self {
+        let mut formated = input.to_string();
+        formated = formated.replace(';', ";\n"); // separate lines by ;
+
+        Self { input: formated }
+    }
+
+    fn generate(&self) -> String {
+        format!("<?php\n{}", self.input)
+    }
+
+    fn needs_boilerplate(&self) -> bool {
+        for m in PHP_START_REGEX.captures_iter(&self.input) {
+            if m.name("php_start").is_some() {
+                return false;
+            }
+        }
+        true
+    }
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,26 +1,31 @@
-use serenity::model::prelude::UnavailableGuild;
 use serenity::{
-    async_trait, collector::CollectReaction, framework::standard::macros::hook,
-    framework::standard::CommandResult, framework::standard::DispatchError,
-    model::channel::Message, model::channel::ReactionType, model::event::MessageUpdateEvent,
-    model::gateway::Ready, model::guild::Guild, model::id::ChannelId, model::id::GuildId,
-    model::id::MessageId, model::interactions::Interaction, prelude::*,
+    async_trait,
+    collector::CollectReaction,
+    framework::{standard::macros::hook, standard::CommandResult, standard::DispatchError},
+    model::{
+        channel::Message, channel::ReactionType, event::MessageUpdateEvent, gateway::Ready,
+        guild::Guild, id::ChannelId, id::GuildId, id::MessageId, interactions::Interaction,
+        prelude::UnavailableGuild,
+    },
+    prelude::*,
 };
 
 use tokio::sync::MutexGuard;
 
 use chrono::{DateTime, Utc};
 
+use crate::managers::command::CommandManager;
 use crate::{
     cache::*,
     commands::compile::handle_request,
     managers::compilation::RequestHandler,
     managers::stats::StatsManager,
-    utls::discordhelpers,
-    utls::discordhelpers::embeds,
-    utls::discordhelpers::embeds::embed_message,
-    utls::discordhelpers::interactions::send_error_msg,
-    utls::parser::{get_message_attachment, shortname_to_qualified},
+    utls::{
+        discordhelpers,
+        discordhelpers::embeds,
+        discordhelpers::interactions::send_error_msg,
+        parser::{get_message_attachment, shortname_to_qualified},
+    },
 };
 
 pub struct Handler; // event handler for serenity
@@ -62,6 +67,13 @@ impl ShardsReadyHandler for Handler {
 impl EventHandler for Handler {
     async fn guild_create(&self, ctx: Context, guild: Guild) {
         let data = ctx.data.read().await;
+
+        // in debug, we'll clean out old commands and register on a guild-per-guild basis
+        if cfg!(debug_assertions) {
+            CommandManager::remove_guild_commands(&ctx, &guild).await;
+            let mut cmd_mgr = data.get::<CommandCache>().unwrap().write().await;
+            cmd_mgr.register_commands_guild(&ctx, &guild).await;
+        }
 
         let now: DateTime<Utc> = Utc::now();
         if guild.joined_at.unix_timestamp() + 30 > now.timestamp() {
@@ -216,7 +228,7 @@ impl EventHandler for Handler {
                                 return;
                             }
                         };
-                        let mut emb_msg = embed_message(emb);
+                        let mut emb_msg = embeds::embed_message(emb);
                         emb_msg.reference_message(&new_message);
                         let _ = new_message
                             .channel_id
@@ -266,9 +278,9 @@ impl EventHandler for Handler {
 
     async fn ready(&self, ctx: Context, ready: Ready) {
         info!("[Shard {}] Ready", ctx.shard_id);
+        let data = ctx.data.read().await;
 
         {
-            let data = ctx.data.read().await;
             let mut stats = data.get::<StatsManagerCache>().unwrap().lock().await;
             // occasionally we can have a ready event fire well after execution
             // this check prevents us from double calling all_shards_ready
@@ -286,16 +298,11 @@ impl EventHandler for Handler {
             }
         }
 
-        // tokio::task::spawn(async move {
-        //     let ctx = ctx.clone();
-        //     let data = ctx.data.read().await;
-        //     let cmd_mgr = data.get::<CommandCache>().unwrap().read().await;
-        //     cmd_mgr.register_commands(&ctx).await;
-        //     info!("[Shard {}] Registered commands", ctx.shard_id);
-        // });
-        let data = ctx.data.read().await;
-        let mut cmd_mgr = data.get::<CommandCache>().unwrap().write().await;
-        cmd_mgr.register_commands(&ctx).await;
+        // register commands globally in release
+        if !cfg!(debug_assertions) {
+            let mut cmd_mgr = data.get::<CommandCache>().unwrap().write().await;
+            cmd_mgr.register_commands_global(&ctx).await;
+        }
     }
 
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .join(", ")
     );
 
+    if cfg!(debug_assertions) {
+        warn!("Running bot in DEBUG mode...");
+    }
+
     let prefix = env::var("BOT_PREFIX").expect("Expected bot prefix in .env file");
     let app_id = env::var("APPLICATION_ID").expect("Expected application id in .env file");
     let framework = StandardFramework::new()

--- a/src/managers/command.rs
+++ b/src/managers/command.rs
@@ -46,6 +46,7 @@ impl CommandManager {
             "cpp" => slashcmds::cpp::cpp(ctx, command).await,
             "invite" => slashcmds::invite::invite(ctx, command).await,
             "format" => slashcmds::format::format(ctx, command).await,
+            "diff" => slashcmds::diff::diff(ctx, command).await,
             e => {
                 println!("OTHER: {}", e);
                 Ok(())
@@ -105,6 +106,23 @@ impl CommandManager {
                                 .name("input")
                                 .kind(ApplicationCommandOptionType::String)
                                 .description("Geordi-like input")
+                        })
+                });
+                builder.create_application_command(|cmd| {
+                    cmd.kind(ApplicationCommandType::ChatInput)
+                        .name("diff")
+                        .description("Posts a diff of two messages' code blocks.")
+                        .create_option(|opt| {
+                            opt.required(true)
+                                .name("message1")
+                                .kind(ApplicationCommandOptionType::String)
+                                .description("Message id of first code-block")
+                        })
+                        .create_option(|opt| {
+                            opt.required(true)
+                                .name("message2")
+                                .kind(ApplicationCommandOptionType::String)
+                                .description("Message id of second code-block")
                         })
                 });
 

--- a/src/managers/command.rs
+++ b/src/managers/command.rs
@@ -1,23 +1,28 @@
 use crate::cache::StatsManagerCache;
-use crate::{cache::CompilerCache, slashcmds};
-use serenity::model::interactions::application_command::ApplicationCommand;
+use crate::slashcmds;
+
 use serenity::{
+    builder::CreateApplicationCommand,
     client::Context,
     framework::standard::CommandResult,
-    model::interactions::application_command::{
-        ApplicationCommandInteraction, ApplicationCommandOptionType, ApplicationCommandType,
+    model::{
+        guild::Guild, interactions::application_command::ApplicationCommand,
+        interactions::application_command::ApplicationCommandInteraction,
+        interactions::application_command::ApplicationCommandOptionType,
+        interactions::application_command::ApplicationCommandType,
     },
 };
-use std::collections::HashMap;
 
 pub struct CommandManager {
-    command_registered: bool,
+    commands_registered: bool,
+    commands: Vec<CreateApplicationCommand>,
 }
 
 impl CommandManager {
     pub fn new() -> Self {
         CommandManager {
-            command_registered: false,
+            commands_registered: false,
+            commands: CommandManager::build_commands(),
         }
     }
 
@@ -39,99 +44,148 @@ impl CommandManager {
         }
 
         match command_name.as_str() {
-            "compile" => slashcmds::compile::compile(ctx, command).await,
-            "assembly" => slashcmds::asm::asm(ctx, command).await,
+            "compile" | "compile [beta]" => slashcmds::compile::compile(ctx, command).await,
+            "assembly" | "assembly [beta]" => slashcmds::asm::asm(ctx, command).await,
             "ping" => slashcmds::ping::ping(ctx, command).await,
             "help" => slashcmds::help::help(ctx, command).await,
             "cpp" => slashcmds::cpp::cpp(ctx, command).await,
             "invite" => slashcmds::invite::invite(ctx, command).await,
-            "format" => slashcmds::format::format(ctx, command).await,
+            "format" | "format [beta]" => slashcmds::format::format(ctx, command).await,
             "diff" => slashcmds::diff::diff(ctx, command).await,
             e => {
-                println!("OTHER: {}", e);
+                warn!("Unknown application command received: {}", e);
                 Ok(())
             }
         }
     }
 
-    pub async fn register_commands(&mut self, ctx: &Context) {
-        if self.command_registered {
-            return;
+    pub async fn remove_guild_commands(ctx: &Context, guild: &Guild) {
+        if let Ok(commands) = guild.get_application_commands(&ctx.http).await {
+            for cmd in commands {
+                let _ = guild.delete_application_command(&ctx.http, cmd.id).await;
+            }
         }
-        self.command_registered = true;
+    }
 
-        let data_read = ctx.data.read().await;
-        let compiler_cache = data_read.get::<CompilerCache>().unwrap();
-        let compiler_manager = compiler_cache.read().await;
-
-        let mut godbolt_dict = HashMap::new();
-        for cache_entry in &compiler_manager.gbolt.cache {
-            godbolt_dict.insert(
-                cache_entry.language.name.clone(),
-                cache_entry.language.id.clone(),
-            );
-        }
-        if let Err(err) =
-            ApplicationCommand::set_global_application_commands(&ctx.http, |builder| {
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::Message).name("Compile")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::Message).name("Assembly")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::Message).name("Format")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("help")
-                        .description("Information on how to use the compiler")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("invite")
-                        .description("Grab my invite link to invite me to your server")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("ping")
-                        .description("Test my ping to Discord's endpoint")
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("cpp")
-                        .description("Shorthand C++ compilation using geordi-like syntax")
-                        .create_option(|opt| {
-                            opt.required(false)
-                                .name("input")
-                                .kind(ApplicationCommandOptionType::String)
-                                .description("Geordi-like input")
-                        })
-                });
-                builder.create_application_command(|cmd| {
-                    cmd.kind(ApplicationCommandType::ChatInput)
-                        .name("diff")
-                        .description("Posts a diff of two messages' code blocks.")
-                        .create_option(|opt| {
-                            opt.required(true)
-                                .name("message1")
-                                .kind(ApplicationCommandOptionType::String)
-                                .description("Message id of first code-block")
-                        })
-                        .create_option(|opt| {
-                            opt.required(true)
-                                .name("message2")
-                                .kind(ApplicationCommandOptionType::String)
-                                .description("Message id of second code-block")
-                        })
-                });
-
-                builder
+    pub async fn register_commands_guild(&mut self, ctx: &Context, guild: &Guild) {
+        match guild
+            .set_application_commands(&ctx.http, |setter| {
+                setter.set_application_commands(self.commands.clone())
             })
             .await
         {
-            error!("Unable to create application commands: {}", err);
+            Err(e) => error!(
+                "Unable to set application commands for guild '{}': {}",
+                guild.id, e
+            ),
+            Ok(commands) => info!(
+                "Registered {} commands in guild: {}",
+                commands.len(),
+                guild.id
+            ),
         }
-        info!("Registered application commands");
+    }
+
+    pub async fn register_commands_global(&mut self, ctx: &Context) {
+        if self.commands_registered {
+            return;
+        }
+        self.commands_registered = true;
+
+        match ApplicationCommand::set_global_application_commands(&ctx.http, |setter| {
+            setter.set_application_commands(self.commands.clone())
+        })
+        .await
+        {
+            Ok(cmds) => info!("Registered {} application commands", cmds.len()),
+            Err(e) => error!("Unable to set application commands: {}", e),
+        }
+    }
+
+    pub fn build_commands() -> Vec<CreateApplicationCommand> {
+        let mut cmds = Vec::new();
+
+        let mut cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::Message).name(format!(
+            "Compile{}",
+            if cfg!(debug_assertions) {
+                " [BETA]"
+            } else {
+                ""
+            }
+        ));
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::Message).name(format!(
+            "Assembly{}",
+            if cfg!(debug_assertions) {
+                " [BETA]"
+            } else {
+                ""
+            }
+        ));
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::Message).name(format!(
+            "Format{}",
+            if cfg!(debug_assertions) {
+                " [BETA]"
+            } else {
+                ""
+            }
+        ));
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("help")
+            .description("Information on how to use the compiler");
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("invite")
+            .description("Grab my invite link to invite me to your server");
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("ping")
+            .description("Test my ping to Discord's endpoint");
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("cpp")
+            .description("Shorthand C++ compilation using geordi-like syntax")
+            .create_option(|opt| {
+                opt.required(false)
+                    .name("input")
+                    .kind(ApplicationCommandOptionType::String)
+                    .description("Geordi-like input")
+            });
+        cmds.push(cmd);
+
+        cmd = CreateApplicationCommand::default();
+        cmd.kind(ApplicationCommandType::ChatInput)
+            .name("diff")
+            .description("Posts a diff of two message code blocks")
+            .create_option(|opt| {
+                opt.required(true)
+                    .name("message1")
+                    .kind(ApplicationCommandOptionType::String)
+                    .description("Message id of first code-block")
+            })
+            .create_option(|opt| {
+                opt.required(true)
+                    .name("message2")
+                    .kind(ApplicationCommandOptionType::String)
+                    .description("Message id of second code-block")
+            });
+        cmds.push(cmd);
+
+        cmds
     }
 }

--- a/src/slashcmds/asm.rs
+++ b/src/slashcmds/asm.rs
@@ -32,5 +32,6 @@ pub async fn asm(ctx: &Context, command: &ApplicationCommandInteraction) -> Comm
         },
     )
     .await?;
+    debug!("Command executed");
     Ok(())
 }

--- a/src/slashcmds/compile.rs
+++ b/src/slashcmds/compile.rs
@@ -34,5 +34,6 @@ pub async fn compile(ctx: &Context, command: &ApplicationCommandInteraction) -> 
         },
     )
     .await?;
+    debug!("Command executed");
     Ok(())
 }

--- a/src/slashcmds/cpp.rs
+++ b/src/slashcmds/cpp.rs
@@ -65,5 +65,7 @@ pub async fn cpp(ctx: &Context, msg: &ApplicationCommandInteraction) -> CommandR
         })
         .await?;
     }
+
+    debug!("Command executed");
     Ok(())
 }

--- a/src/slashcmds/diff.rs
+++ b/src/slashcmds/diff.rs
@@ -1,0 +1,138 @@
+use serenity::{
+    framework::standard::CommandResult,
+    model::interactions::application_command::ApplicationCommandInteraction,
+    model::interactions::application_command::ApplicationCommandInteractionDataOptionValue,
+    model::prelude::*, prelude::*,
+};
+
+use similar::ChangeTag;
+
+use crate::{
+    utls::constants::COLOR_FAIL, utls::constants::COLOR_OKAY, utls::parser::find_code_block,
+    utls::parser::ParserResult,
+};
+
+pub async fn diff(ctx: &Context, msg: &ApplicationCommandInteraction) -> CommandResult {
+    let message1 = msg
+        .data
+        .options
+        .get(0)
+        .expect("Expected interaction option 0")
+        .resolved
+        .as_ref()
+        .expect("Expected data option value");
+
+    let message2 = msg
+        .data
+        .options
+        .get(1)
+        .expect("Expected interaction option 1")
+        .resolved
+        .as_ref()
+        .expect("Expected data option value");
+
+    let mut message1_parse = None;
+    if let ApplicationCommandInteractionDataOptionValue::String(input) = message1 {
+        message1_parse = input.parse::<u64>().ok();
+    }
+    let mut message2_parse = None;
+    if let ApplicationCommandInteractionDataOptionValue::String(input) = message2 {
+        message2_parse = input.parse::<u64>().ok();
+    }
+
+    if message1_parse.is_none() || message2_parse.is_none() {
+        msg.create_interaction_response(&ctx.http, |resp| {
+            resp.interaction_response_data(|data| {
+                data.embed(|emb| {
+                    emb.color(COLOR_FAIL).description(
+                        "Invalid message ID specified!\n\n\
+                        Right click a message and select 'Copy ID' at the bottom. If you cannot \
+                        see this option then you must first enable Developer Mode by going to the \
+                        User Settings > Advanced tab",
+                    )
+                })
+                .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+            })
+        })
+        .await?;
+        return Ok(());
+    }
+
+    let message1_obj = ctx
+        .http
+        .get_message(msg.channel_id.0, message1_parse.unwrap())
+        .await
+        .ok();
+    let message2_obj = ctx
+        .http
+        .get_message(msg.channel_id.0, message2_parse.unwrap())
+        .await
+        .ok();
+    if message1_obj.is_none() || message2_obj.is_none() {
+        msg.create_interaction_response(&ctx.http, |resp| {
+            resp.interaction_response_data(|data| {
+                data.embed(|emb| {
+                    emb.color(COLOR_FAIL).description(
+                        "Unable to find message.\n\nEnsure both messages belong to \
+                        this channel and the Message IDs are correct.",
+                    )
+                })
+                .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+            })
+        })
+        .await?;
+        return Ok(());
+    }
+
+    let content1 = message1_obj.unwrap().content;
+    let content2 = message2_obj.unwrap().content;
+
+    let mut fake_parse1 = ParserResult::default();
+    let mut fake_parse2 = ParserResult::default();
+
+    {
+        let block1 = find_code_block(&mut fake_parse1, &content1, &msg.user);
+        let block2 = find_code_block(&mut fake_parse2, &content2, &msg.user);
+
+        if !block1.await? || !block2.await? {
+            msg.create_interaction_response(&ctx.http, |resp| {
+                resp.interaction_response_data(|data| {
+                    data.embed(|emb| {
+                        emb.color(COLOR_FAIL).description(
+                            "Unable to find a code-block to match within a supplied message!",
+                        )
+                    })
+                    .flags(InteractionApplicationCommandCallbackDataFlags::EPHEMERAL)
+                })
+            })
+            .await?;
+            return Ok(());
+        }
+    }
+
+    let code1 = fake_parse1.code.clone();
+    let code2 = fake_parse2.code.clone();
+    let diff = similar::TextDiff::from_lines(&code1, &code2);
+    let mut output = String::new();
+    for change in diff.iter_all_changes() {
+        let sign = match change.tag() {
+            ChangeTag::Delete => "-",
+            ChangeTag::Insert => "+",
+            ChangeTag::Equal => " ",
+        };
+        output.push_str(&format!("{}{}", sign, change));
+    }
+
+    msg.create_interaction_response(&ctx.http, |resp| {
+        resp.interaction_response_data(|data| {
+            data.embed(|emb| {
+                emb.color(COLOR_OKAY)
+                    .title("Diff completed")
+                    .description(format!("```diff\n{}\n```", output))
+            })
+        })
+    })
+    .await?;
+
+    Ok(())
+}

--- a/src/slashcmds/diff.rs
+++ b/src/slashcmds/diff.rs
@@ -133,6 +133,6 @@ pub async fn diff(ctx: &Context, msg: &ApplicationCommandInteraction) -> Command
         })
     })
     .await?;
-
+    debug!("Command executed");
     Ok(())
 }

--- a/src/slashcmds/invite.rs
+++ b/src/slashcmds/invite.rs
@@ -21,6 +21,6 @@ pub async fn invite(ctx: &Context, msg: &ApplicationCommandInteraction) -> Comma
             .interaction_response_data(|data| data.add_embed(emb))
     })
     .await?;
-
+    debug!("Command executed");
     Ok(())
 }

--- a/src/slashcmds/mod.rs
+++ b/src/slashcmds/mod.rs
@@ -1,6 +1,7 @@
 pub mod asm;
 pub mod compile;
 pub mod cpp;
+pub mod diff;
 pub mod format;
 pub mod help;
 pub mod invite;

--- a/src/slashcmds/ping.rs
+++ b/src/slashcmds/ping.rs
@@ -19,5 +19,6 @@ pub async fn ping(ctx: &Context, msg: &ApplicationCommandInteraction) -> Command
         resp.content(format!("🏓 Pong!\n{} ms", (new - old).as_millis()))
     })
     .await?;
+    debug!("Command executed");
     Ok(())
 }

--- a/src/utls/constants.rs
+++ b/src/utls/constants.rs
@@ -27,17 +27,19 @@ pub const URL_ALLOW_LIST: [&str; 4] = [
 // Boilerplate Regexes
 lazy_static! {
     pub static ref JAVA_MAIN_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<main>void[\\s]+?main[\\s]*?\\()").unwrap();
+        Regex::new("\"[^\"]*?\"|(?P<main>void[\\s]+?main[\\s]*?\\()").unwrap();
     pub static ref C_LIKE_MAIN_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<main>main[\\s]*?\\()").unwrap();
+        Regex::new("\"[^\"]*?\"|(?P<main>main[\\s]*?\\()").unwrap();
     pub static ref CSHARP_MAIN_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
+        Regex::new("\"[^\"]*?\"|(?P<main>static[\\s]+?void[\\s]+?Main[\\s]*?\\()").unwrap();
+    pub static ref PHP_START_REGEX: Regex =
+        Regex::new("\"[^\"]*?\"|(?P<php_start><\\?php)").unwrap();
 }
 
 // Other Regexes
 lazy_static! {
     pub static ref JAVA_PUBLIC_CLASS_REGEX: Regex =
-        Regex::new("\"[^\"]+\"|(?P<public>public)[\\s]+?class[\\s]*?").unwrap();
+        Regex::new("\"[^\"]*?\"|(?P<public>public)[\\s]+?class[\\s]*?").unwrap();
 }
 
 /*

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -88,7 +88,14 @@ pub async fn handle_edit(
     };
 
     // try to clear reactions
-    let _ = old.delete_reactions(&ctx).await;
+    // let _ = old.delete_reactions(&ctx).await;
+    if let Ok(updated_message) = old.channel_id.message(&ctx.http, old.id.0).await {
+        for reaction in &updated_message.reactions {
+            if reaction.me {
+                let _ = discordhelpers::delete_bot_reacts(ctx, &updated_message, reaction.reaction_type.clone()).await;
+            }
+        }
+    }
 
     if content.starts_with(&format!("{}asm", prefix)) {
         if let Err(e) = handle_edit_asm(

--- a/src/utls/discordhelpers/mod.rs
+++ b/src/utls/discordhelpers/mod.rs
@@ -92,7 +92,12 @@ pub async fn handle_edit(
     if let Ok(updated_message) = old.channel_id.message(&ctx.http, old.id.0).await {
         for reaction in &updated_message.reactions {
             if reaction.me {
-                let _ = discordhelpers::delete_bot_reacts(ctx, &updated_message, reaction.reaction_type.clone()).await;
+                let _ = discordhelpers::delete_bot_reacts(
+                    ctx,
+                    &updated_message,
+                    reaction.reaction_type.clone(),
+                )
+                .await;
             }
         }
     }


### PR DESCRIPTION
This command (implemented as a slash command) allows users to diff code-blocks as they wish.

Sometimes it's difficult to quickly identify changes people make between posts, so this command will help isolate those changes in a diff format.